### PR TITLE
Fix capture bug and add tasks

### DIFF
--- a/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
+++ b/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
@@ -89,15 +89,19 @@ public abstract class GooeyDisplayable<T> {
 				Thread.sleep( 200 ); // hack: waiting to give Swing threads a chance to update.
 				close( captured );
 			}
-		} catch (ExecutionException e) {
-			Throwable t = e.getCause();
-			if (t instanceof RuntimeException runtime) {
-				throw runtime;
-			}
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-			Thread.currentThread().interrupt();
-		} finally {
+                } catch (ExecutionException e) {
+                        Throwable t = e.getCause();
+                        if (t instanceof RuntimeException runtime) {
+                                throw runtime;
+                        } else if (t instanceof AssertionError assertion) {
+                                throw assertion;
+                        } else {
+                                throw new RuntimeException(t);
+                        }
+                } catch (InterruptedException e) {
+                        e.printStackTrace();
+                        Thread.currentThread().interrupt();
+                } finally {
 			setEnableCapture( false );
 		}
 	}

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,5 @@
+- Set explicit versions for dependencies in `gooey/lib/build.gradle.kts` instead of using the `+` version syntax.
+- Add instructions in `README.md` on how to run tests using Gradle Wrapper.
+- Configure a GitHub Actions workflow to run `./gradlew test` on pull requests.
+- Improve error handling in `GooeyDisplayable.capture()` so that all exceptions are propagated correctly.
+- Add Javadoc comments for recently added classes and methods.


### PR DESCRIPTION
## Summary
- add TODOs for future improvements
- propagate assertion errors correctly in `GooeyDisplayable.capture`

## Testing
- `javac gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java -d /tmp/classes`
- `xargs -a /tmp/sources.txt javac -d /tmp/classes`
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851d7c8bf7483249da80570711d84c7