### PR TITLE
Fix capture race and add regression test

### DIFF
--- a/gooey/src/main/java/edu/cnu/cs/gooey/GooeySwingToolkitListener.java
+++ b/gooey/src/main/java/edu/cnu/cs/gooey/GooeySwingToolkitListener.java
@@ -34,20 +34,29 @@ public class GooeySwingToolkitListener<T> implements GooeyToolkitListener<T>, AW
 		this.criteria = criteria;
 	}
 	@Override
-	public void setEnableCapture(boolean on) {
-		if (on) TOOLKIT.   addAWTEventListener( this, AWTEvent.WINDOW_EVENT_MASK );
-		else    TOOLKIT.removeAWTEventListener( this );
-	}
-	public T getTarget() {
-//		Debug.Me("wait++++++");
-		synchronized(this) {
-			try {
-				wait();
-			} catch (InterruptedException e) {
-			}
-		}
-//		Debug.Me("wait------");
-		return target;
+        public void setEnableCapture(boolean on) {
+                if (on) {
+                        synchronized(this) {
+                                target = null;
+                        }
+                        TOOLKIT.addAWTEventListener( this, AWTEvent.WINDOW_EVENT_MASK );
+                } else {
+                        TOOLKIT.removeAWTEventListener( this );
+                }
+        }
+        public T getTarget() {
+//              Debug.Me("wait++++++");
+                synchronized(this) {
+                        while (target == null) {
+                                try {
+                                        wait();
+                                } catch (InterruptedException e) {
+                                }
+                        }
+                }
+//              Debug.Me("wait------");
+                return target;
+
 	}
 //	private String get(AWTEvent event) {
 //		int    id = event.getID();

--- a/gooey/src/test/java/SwingMultipleCaptureTest.java
+++ b/gooey/src/test/java/SwingMultipleCaptureTest.java
@@ -1,0 +1,41 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.swing.JFrame;
+
+import org.junit.jupiter.api.Test;
+
+import edu.cnu.cs.gooey.Gooey;
+import edu.cnu.cs.gooey.GooeyFrame;
+
+public class SwingMultipleCaptureTest {
+    @Test
+    public void testTwoSequentialCaptures() {
+        Gooey.capture(new GooeyFrame() {
+            @Override
+            public void invoke() {
+                JFrame frame = new JFrame("first");
+                frame.setSize(100, 100);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            }
+            @Override
+            public void test(JFrame frame) {
+                assertEquals("first", frame.getTitle());
+            }
+        });
+
+        Gooey.capture(new GooeyFrame() {
+            @Override
+            public void invoke() {
+                JFrame frame = new JFrame("second");
+                frame.setSize(100, 100);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            }
+            @Override
+            public void test(JFrame frame) {
+                assertEquals("second", frame.getTitle());
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- clear previous capture target when enabling capture
- wait for window events in a loop to avoid missed notifications
- add regression test for repeated captures

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685181e82ad88324965169813b53d5f2