### PR TITLE
Improve capture error propagation

### DIFF
--- a/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
+++ b/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
@@ -93,16 +93,16 @@ public abstract class GooeyDisplayable<T> {
                         Throwable t = e.getCause();
                         if (t instanceof RuntimeException runtime) {
                                 throw runtime;
-                        } else if (t instanceof AssertionError assertion) {
-                                throw assertion;
+                        } else if (t instanceof Error error) {
+                                throw error;
                         } else {
                                 throw new RuntimeException(t);
                         }
                 } catch (InterruptedException e) {
-                        e.printStackTrace();
                         Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
                 } finally {
-			setEnableCapture( false );
-		}
+                        setEnableCapture( false );
+                }
 	}
 }


### PR DESCRIPTION
## Summary
- propagate runtime and error causes in `GooeyDisplayable.capture`
- rethrow `InterruptedException` rather than printing it

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68547c59f77483249870ff102655a15f