### PR TITLE
Fix dependency versions

### DIFF
--- a/gooey/lib/build.gradle.kts
+++ b/gooey/lib/build.gradle.kts
@@ -19,11 +19,11 @@ repositories {
 }
 
 dependencies {
-    implementation ( "org.junit.jupiter:junit-jupiter:5.12.+" )     // 5.12.x https://junit.org/junit5/
+    implementation ( "org.junit.jupiter:junit-jupiter:5.12.0" )     // 5.12.x https://junit.org/junit5/
     testRuntimeOnly( "org.junit.platform:junit-platform-launcher" ) // 5.12.0 test discovery https://github.com/gradle/gradle/issues/32534
 
-    implementation( "org.awaitility:awaitility:+" )
-    implementation( "com.google.truth:truth:+" )                    // 1.4.4  https://truth.dev/
+    implementation( "org.awaitility:awaitility:4.2.0" )
+    implementation( "com.google.truth:truth:1.4.4" )                    // 1.4.4  https://truth.dev/
 }
 
 java {


### PR DESCRIPTION
## Summary
- specify concrete versions for junit-jupiter, awaitility, and truth

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68569db89b388324ab73ba7aa58efa65