### PR TITLE
Add Javadoc to GooeyWindow and toolkit listener

### DIFF
--- a/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyToolkitListener.java
+++ b/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyToolkitListener.java
@@ -1,6 +1,25 @@
 package edu.cnu.cs.gooey;
 
+/**
+ * Listener interface used by Gooey to monitor window events.
+ * Implementations are responsible for enabling or disabling
+ * event capture and providing access to the captured window.
+ *
+ * @param <T> type of window being captured
+ */
 public interface GooeyToolkitListener<T> {
-	void setEnableCapture(boolean on);
-	T    getTarget();
+        /**
+         * Enables or disables event capture for the implementing listener.
+         *
+         * @param on {@code true} to start capturing events, {@code false} to stop
+         */
+        void setEnableCapture(boolean on);
+
+        /**
+         * Returns the window instance that has been captured by the listener.
+         * This call blocks until a window matching the criteria is available.
+         *
+         * @return captured window instance
+         */
+        T getTarget();
 }

--- a/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyWindow.java
+++ b/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyWindow.java
@@ -20,7 +20,15 @@ import java.util.function.Predicate;
 
 import javax.swing.SwingUtilities;
 
-public abstract class GooeyWindow <T extends Window> extends GooeyDisplayable<T> {
+/**
+ * Base class for {@link java.awt.Window} based displayables used in Gooey
+ * tests.  Subclasses define the specific window type that will be captured
+ * and provide the {@link GooeyDisplayable} hooks for invoking and testing the
+ * window.
+ *
+ * @param <T> concrete type of {@link Window} this instance captures
+ */
+public abstract class GooeyWindow<T extends Window> extends GooeyDisplayable<T> {
 	private final GooeySwingToolkitListener<T> listener;
 
 	protected GooeyWindow(final Class<T> type, String noWindowMessage) {


### PR DESCRIPTION
## Summary
- document `GooeyToolkitListener` interface and its methods
- add class description for `GooeyWindow`

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856a13a4b4c83248627c93ce2675f53