### PR TITLE
Fix executor cleanup in capture()

### DIFF
--- a/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
+++ b/gooey/lib/src/main/java/edu/cnu/cs/gooey/GooeyDisplayable.java
@@ -101,8 +101,9 @@ public abstract class GooeyDisplayable<T> {
                 } catch (InterruptedException e) {
                         e.printStackTrace();
                         Thread.currentThread().interrupt();
-                } finally {
-			setEnableCapture( false );
-		}
-	}
+               } finally {
+                       executor.shutdownNow();
+                       setEnableCapture( false );
+               }
+       }
 }


### PR DESCRIPTION
## Summary
- ensure ExecutorService is shut down after capture by calling `shutdownNow()`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856a1dc4498832483eba13a012b58bc